### PR TITLE
feat: add plugin sdk for custom widgets

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,5 +84,25 @@ cd Deep-Canvas
 npm install
 npm run dev
 ```
+
+## Plugin SDK
+
+Create custom widgets by dropping JavaScript files into `app/plugins`.
+Each plugin exports a `register(api)` function. Use `api.registerWidget`
+to add buttons to the canvas dock.
+
+```js
+// app/plugins/hello-plugin.js
+export function register(api) {
+  api.registerWidget({
+    id: 'helloPlugin',
+    label: 'Hello',
+    html: '👋',
+    onClick: () => alert('Hello from plugin!')
+  });
+}
+```
+
+Restart the app to load new plugins.
 ---
 I accept any new ideas That can make Deep Canvas Better and Will Try my best to Fulfill any idea that you given :)

--- a/app/plugins/hello-plugin.js
+++ b/app/plugins/hello-plugin.js
@@ -1,0 +1,8 @@
+export function register(api) {
+  api.registerWidget({
+    id: 'helloPlugin',
+    label: 'Hello',
+    html: '👋',
+    onClick: () => alert('Hello from plugin!')
+  });
+}

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -15,6 +15,7 @@ import { paintAtPoint } from './tools/paint.js';
 import { PanTool } from './tools/pan.js';
 import { attachHistory } from './history.js';
 import { initGalleryView, showGallery, hideGallery } from './gallery.js';
+import { initPlugins } from './plugins.js';
 document.documentElement.setAttribute('data-theme', 'dark');
 
 import {
@@ -938,6 +939,7 @@ const uiAPI = initUI({
 });
 
 window._endless = { state, camera, grid };
+initPlugins();
 
 subscribe(() => {
   const stats = render(state, camera, ctx, canvas, { dpr });

--- a/app/src/plugins.js
+++ b/app/src/plugins.js
@@ -1,0 +1,31 @@
+export async function initPlugins() {
+  const paths = (window.pluginHost && typeof window.pluginHost.list === 'function')
+    ? window.pluginHost.list()
+    : [];
+  const api = { registerWidget };
+  for (const p of paths) {
+    try {
+      const mod = await import(p);
+      if (mod && typeof mod.register === 'function') {
+        mod.register(api);
+      }
+    } catch (err) {
+      console.error('Plugin failed', p, err);
+    }
+  }
+}
+
+function registerWidget({ id, label, html, onClick }) {
+  const dock = document.querySelector('.dock-group.tools');
+  if (!dock) return null;
+  const btn = document.createElement('button');
+  btn.className = 'tool plugin-tool';
+  if (id) btn.id = id;
+  if (label) btn.setAttribute('aria-label', label);
+  btn.innerHTML = html || label || '';
+  if (typeof onClick === 'function') {
+    btn.addEventListener('click', onClick);
+  }
+  dock.appendChild(btn);
+  return btn;
+}

--- a/preload.js
+++ b/preload.js
@@ -1,0 +1,17 @@
+const { contextBridge } = require('electron');
+const fs = require('fs');
+const path = require('path');
+
+function listPlugins() {
+  try {
+    const dir = path.join(__dirname, 'app', 'plugins');
+    const files = fs.readdirSync(dir).filter(f => f.endsWith('.js'));
+    return files.map(f => `../plugins/${f}`);
+  } catch {
+    return [];
+  }
+}
+
+contextBridge.exposeInMainWorld('pluginHost', {
+  list: listPlugins
+});


### PR DESCRIPTION
## Summary
- expose pluginHost API via preload to list plugin scripts
- load plugins at startup and let them register UI widgets
- document new Plugin SDK and include a sample hello plugin

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c29677f2348323812a58c487f138cb